### PR TITLE
Skip on install, added uninstall

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,16 +7,14 @@ INSTALLDIR="${DESTDIR}${PREFIX}/bin/"
 
 # install binaries
 if [[ ! -f "./c/build/lilt" ]]; then
-	echo "no lilt binaries found. build first with 'make lilt'"
-	exit 1
+	echo "skipping lilt. no binary found. build first with 'make lilt'"
 fi
 if [ -f "./c/build/lilt" ]; then
 	echo "copying lilt to ${INSTALLDIR}..."
 	sudo cp ./c/build/lilt "${INSTALLDIR}lilt"
 fi
 if [[ ! -f "./c/build/decker" ]]; then
-	echo "no decker binaries found. build first with 'make decker'"
-	exit 1
+	echo "skipping decker. no binary found. build first with 'make decker'"
 fi
 if [ -f "./c/build/decker" ]; then
 	echo "copying decker to ${INSTALLDIR}..."

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -6,6 +6,7 @@ PREFIX="/usr/local"
 INSTALLDIR="${DESTDIR}${PREFIX}/bin/"
 
 sudo rm -f "${INSTALLDIR}lilt"
+sudo rm -f "${INSTALLDIR}decker"
 
 rm -rf ~/Library/Application\ Support/Sublime\ Text/Packages/Lil.tmbundle
 rm -rf ~/Library/Application\ Support/Sublime\ Text\ 3/Packages/Lil.tmbundle


### PR DESCRIPTION
* Made the install script skip lilt or decker instead of exiting, if the binaries are not found.
* Added decker to the uninstall script.
Fixes #9 