### PR TITLE
Add `-Wno-misleading-indentation` for clang as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ ifeq ($(UNAME),Darwin)
 	OPEN=open
 	COMPILER=clang
 	FLAGS=-Wall -Werror -Wextra -Wpedantic -Os
+	# -Wno-misleading-indentation silences warnings which are entirely spurious.
+	FLAGS:=$(FLAGS) -Wno-misleading-indentation
 	# FLAGS:=$(FLAGS) -fsanitize=undefined
 	# FLAGS:=$(FLAGS) -fsanitize=address
 endif

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ifeq ($(UNAME),Darwin)
 	COMPILER=clang
 	FLAGS=-Wall -Werror -Wextra -Wpedantic -Os
 	# -Wno-misleading-indentation silences warnings which are entirely spurious.
-	FLAGS:=$(FLAGS) -Wno-misleading-indentation
+	FLAGS:=$(FLAGS) -Wno-misleading-indentation -Wno-unknown-warning-option
 	# FLAGS:=$(FLAGS) -fsanitize=undefined
 	# FLAGS:=$(FLAGS) -fsanitize=address
 endif


### PR DESCRIPTION
clang added the same "misleading indentation" warnings as gcc starting with version 10.