### PR TITLE
clear modifiers on focus loss to prevent stuck keys

### DIFF
--- a/js/decker.js
+++ b/js/decker.js
@@ -3505,6 +3505,7 @@ q('body').onkeyup=e=>{
 	}
 	e.preventDefault()
 }
+q('body').onblur=e=>{ev.alt=0,keydown={}}
 let local_clipboard=''
 getclipboard=after=>{
 	const t=document.createElement('textarea');t.style.top='0',t.style.left='0',t.position='fixed',t.onpaste=e=>{e.stopPropagation()}


### PR DESCRIPTION
repro:

1) press Ctrl while using Decker
2) move mouse outside of browser window and click on something else
3) release Ctrl
3) try to use Decker, get confused by click always zooming