### PR TITLE
bugfix: Shift-click to select text

### DIFF
--- a/c/decker.c
+++ b/c/decker.c
@@ -772,7 +772,7 @@ void widget_field(lv*target,field x,field_val*value){
 	}
 	if(!x.locked&&!l&&dover(bi)&&(ev.md||ev.mu||ev.drag)){
 		int i=layout_index((pair){ev.pos.x-bi.x,ev.pos.y-bi.y+value->scroll});
-		if(ev.md){wid.cursor.x=wid.cursor.y=i;}else{wid.cursor.y=i;}
+		if(ev.md&&!ev.shift){wid.cursor.x=wid.cursor.y=i;}else{wid.cursor.y=i;}
 		if(ev.dclick){ // double-click to select a word or whitespace span:
 			int a,w=layout_count&&strchr("\n ",layout[MIN(wid.cursor.y,layout_count-1)].c)?1:0;
 			a=wid.cursor.y;while(a>=0&&a<layout_count&&(w^!strchr("\n ",layout[a].c)))a--;wid.cursor.x=a+1;

--- a/js/decker.js
+++ b/js/decker.js
@@ -874,7 +874,7 @@ widget_field=(target,x,value)=>{
 	}
 	if(!x.locked&&!l&&dover(bi)&&(ev.md||ev.mu||ev.drag)){
 		const i=layout_index(layout,rect(ev.pos.x-bi.x,ev.pos.y-bi.y+value.scroll))
-		if(ev.md){wid.cursor.x=wid.cursor.y=i}else{wid.cursor.y=i}
+		if(ev.md&&!ev.shift){wid.cursor.x=wid.cursor.y=i}else{wid.cursor.y=i}
 		if(ev.dclick){ // double-click to select a word or whitespace span:
 			let a=0, w=layout.layout.length&&/\s/g.test(layout.layout[min(wid.cursor.y,layout.layout.length-1)].char)
 			a=wid.cursor.y;while(a>=0&&a<layout.layout.length&&(w^!/\s/g.test(layout.layout[a].char)))a--;wid.cursor.x=a+1


### PR DESCRIPTION
This commit allows the user to adjust the selected text by shift-clicking.

Tested and confirmed working correctly in both the C and JS versions (tested JS on Vivaldi (latest) for Windows 10 and C on Mac OS 13.2.1)