### PR TITLE
Makefile: Add EXTRA_FLAGS for on-demand compile flag changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 VERSION=$(shell cat VERSION)
 UNAME=$(shell uname)
 SDL=$(shell sdl2-config --cflags --libs)
+EXTRA_FLAGS?=
 
 ifeq ($(UNAME),Darwin)
 	OPEN=open
@@ -36,6 +37,9 @@ ifneq ("$(wildcard /usr/bin/olpc-hwinfo)","")
 	FLAGS:=$(FLAGS) -DLOSPEC
 else
 	SDL:=$(SDL) -lSDL2_image
+endif
+ifneq ("$(EXTRA_FLAGS)","")
+	FLAGS:=$(FLAGS) $(EXTRA_FLAGS)
 endif
 
 resources:


### PR DESCRIPTION
This commit adds an EXTRA_FLAGS variable to the Makefile, which can be set through the environment as needed. The contents will be appended to the FLAGS variable, allowing the developer to (for example) disable stringent checks for certain warnings during compile.

This can be used as follows: `EXTRA_FLAGS=-Wno-strict-prototypes make decker`

I realise that this might be unnecessary for most, but I ran into an issue when compiling Decker on Mac OS (`-Wstrict-prototypes` was flagging every function declaration, and `-Werror` was treating them as errors, and the default `-ferror-limit=20` was killing the build after 20 errors) and it didn't feel quite right to edit the Makefile locally. Hopefully this helps? 