### PR TITLE
SDL1.2 implementation

### DIFF
--- a/c/decker.c
+++ b/c/decker.c
@@ -4,7 +4,12 @@
 
 int should_exit=0;
 
+#include <SDL_version.h>
+#if SDL_VERSION_ATLEAST(2,0,0)
 #include "io_sdl2.h"
+#else
+#include "io_sdl1.h"
+#endif
 
 void save_deck(lv*path); // forward refs
 void load_deck(lv*deck);

--- a/c/decker.c
+++ b/c/decker.c
@@ -3207,7 +3207,7 @@ void event_touch(void){
 	if(!set_touch)enable_touch=1;
 }
 void event_key(int c,int m,int down,const char*name){
-	int cmd=m&(KMOD_LCTRL|KMOD_RCTRL|KMOD_LGUI|KMOD_RGUI);
+	int cmd=m&(KEYM_LCTRL|KEYM_RCTRL|KEYM_LGUI|KEYM_RGUI);
 	if(down){
 		if(c>0&&c<4096)keydown[c]=1;
 		if(c==KEY_LSHIFT||c==KEY_RSHIFT)ev.shift=1;
@@ -3235,7 +3235,7 @@ void event_key(int c,int m,int down,const char*name){
 		}
 		if(c==KEY_RETURN)ev.action=1;
 		if     (wid.ingrid )grid_keys(c);
-		else if(wid.infield)field_keys(c,m&(KMOD_LSHIFT|KMOD_RSHIFT));
+		else if(wid.infield)field_keys(c,m&(KEYM_LSHIFT|KEYM_RSHIFT));
 		if(uimode==mode_script)sc.status[0]='\0';
 		if(c==KEY_SPACE&&!wid.infield)ev.action=1;
 		if(c==KEY_TAB   )ev.tab=1;

--- a/c/decker.c
+++ b/c/decker.c
@@ -120,9 +120,9 @@ void draw_invert(char*pal,rect r){
 
 enum uimodes{mode_interact,mode_draw,mode_object,mode_script};
 int uimode=mode_interact;lv*ui_container=NULL;
-void setmode(int mode);// forward ref
+void setuimode(int mode);// forward ref
 void con_set(lv*x){
-	if(x!=ui_container)setmode(uimode),msg.next_view=1;
+	if(x!=ui_container)setuimode(uimode),msg.next_view=1;
 	if(x!=ui_container&&prototype_is(ui_container))n_prototype_update(ui_container,NONE);ui_container=x;
 }
 lv* con(void){return ui_container?ui_container:ifield(deck,"card");}
@@ -382,7 +382,7 @@ void field_exit(void){
 	wid.field_dirty=0,wid.change_timer=0;
 }
 void bg_end_selection(void);void bg_end_lasso(void); // forward-ref
-void setmode(int mode){
+void setuimode(int mode){
 	n_play(NULL,lml2(NONE,lmistr("loop")));
 	grid_exit(),field_exit(),bg_end_selection(),bg_end_lasso(),ob.sel->c=0,wid.active=-1;poly_count=0;sc.others=NULL;
 	msg.next_view   =(uimode!=mode)&&mode==mode_interact;
@@ -391,9 +391,9 @@ void setmode(int mode){
 	if(mode!=mode_draw&&!prototype_is(con()))dr.fatbits=0;
 	if(mode==mode_interact)dr.fatbits=0;
 }
-void settool(int tool){setmode(mode_draw);dr.tool=tool;}
+void settool(int tool){setuimode(mode_draw);dr.tool=tool;}
 void setscript(lv*x){
-	if(uimode!=mode_script)sc.prev_mode=uimode;setmode(mode_script);
+	if(uimode!=mode_script)sc.prev_mode=uimode;setuimode(mode_script);
 	sc.target=lil(x)?x->lv[0]:x, sc.others=lil(x)?l_drop(ONE,x):lml(0);
 	sc.status[0]='\0';lv*v=ifield(sc.target,"script");int p=0;
 	if(!v->c)v=card_is  (sc.target)?(p=1,lmistr("on view do\n \nend")):
@@ -407,7 +407,7 @@ void setscript(lv*x){
 	if(p)snprintf(sc.status,sizeof(sc.status),"No existing script; populated a template.");
 	sc.f=(field_val){rtext_cast(v),0};wid.active=0;
 }
-void finish_script(void){if(sc.next){setscript(sc.next),sc.next=NULL;}else{setmode(sc.prev_mode);}}
+void finish_script(void){if(sc.next){setscript(sc.next),sc.next=NULL;}else{setuimode(sc.prev_mode);}}
 void widget_setup(void){
 	if(ev.mu||wid.active==-1)wid.col_drag=0;
 	if(wid.active>=wid.count)wid.active=0;
@@ -1371,7 +1371,7 @@ void import_image(char*path){
 	int tw=c[0],ow=c[32];c[32]=0,c[47]=0;for(int z=2;z<256;z++)if(c[z]){color=1;break;}
 	if(color&&tw){EACH(z,i->b)i->b->sv[z]=i->b->sv[z]!=0;m=i->b;}
 	if(color){i=readimage(path,1);}else if(ow&&!tw){EACH(z,i->b)i->b->sv[z]=i->b->sv[z]!=32;}
-	setmode(mode_draw),bg_paste(i->b,1);if(color)dr.limbo_dither=1,dither_threshold=0.5;dr.fatbits=0;dr.omask=m;
+	setuimode(mode_draw),bg_paste(i->b,1);if(color)dr.limbo_dither=1,dither_threshold=0.5;dr.fatbits=0;dr.omask=m;
 }
 lv* table_decode(lv*text,lv*format){return ms.edit_json?l_table(l_parse(lmistr("%j"),text)): n_readcsv(NULL,format->c?lml2(text,format):l_list(text));}
 lv* modal_open_path(void){
@@ -2387,7 +2387,7 @@ void apply(int fwd,lv*x){
 	lv* wids=con_wids();
 	if(t==edit_ob_create){fwd=!fwd,t=edit_ob_destroy;}
 	if(t==edit_bg_block){
-		if(uimode!=mode_draw)setmode(mode_draw);
+		if(uimode!=mode_draw)setuimode(mode_draw);
 		rect r=getrect(dget(x,lmistr("pos")));
 		lv*  p=dget(x,lmistr(fwd?"after":"before"));
 		lv* bg=container_image(container,1);pair s=image_size(bg), cs=getpair(ifield(container,"size"));
@@ -2401,12 +2401,12 @@ void apply(int fwd,lv*x){
 		if(!fwd&&cb)buffer_paste(c,clip,cb,bg->b,1);
 	}
 	else if(t==edit_ob_props){
-		if(uimode!=mode_object)setmode(mode_object);
+		if(uimode!=mode_object)setuimode(mode_object);
 		lv* p=dget(x,lmistr(fwd?"after":"before"));
 		EACH(z,p){lv*d=p->lv[z],*w=dget(wids,p->kv[z]);if(w)EACH(i,d)iwrite(w,d->kv[i],d->lv[i]);}
 	}
 	else if(t==edit_ob_destroy){
-		if(uimode!=mode_object)setmode(mode_object);
+		if(uimode!=mode_object)setuimode(mode_object);
 		lv* props=dget(x,lmistr("props"));
 		ob.sel->c=0;
 		if(fwd){
@@ -3146,7 +3146,7 @@ void brushbtn(pair pos,pair dn,rect b,int brush){
 	pair i={b.x+(b.w/2),b.y+(b.h/2)};
 	draw_box(b,0,1),draw_line((rect){i.x,i.y,i.x,i.y},brush,1,deck);
 	if(dr.brush==brush)draw_box(inset(b,2),0,1);
-	if(!box_in(b,pos))return;uicursor=cursor_point;if(!ev.mu||!box_in(b,dn))return;setmode(mode_draw);
+	if(!box_in(b,pos))return;uicursor=cursor_point;if(!ev.mu||!box_in(b,dn))return;setuimode(mode_draw);
 	if(dr.tool==tool_select||dr.tool==tool_lasso||dr.tool==tool_fill)settool(tool_pencil);
 	dr.brush=brush;
 }
@@ -3154,7 +3154,7 @@ void cbrushbtn(pair pos,pair dn,rect b,int brush,lv*bt){
 	lv*icon=bt->lv[brush-24];rect oc=frame.clip;frame.clip=b;
 	rect p=box_center(b,image_size(icon));draw_icon((pair){p.x,p.y},icon,1);frame.clip=oc;draw_box(b,0,1);
 	if(dr.brush==brush)draw_box(inset(b,2),0,1);
-	if(!box_in(b,pos))return;uicursor=cursor_point;if(!ev.mu||!box_in(b,dn))return;setmode(mode_draw);
+	if(!box_in(b,pos))return;uicursor=cursor_point;if(!ev.mu||!box_in(b,dn))return;setuimode(mode_draw);
 	if(dr.tool==tool_select||dr.tool==tool_lasso||dr.tool==tool_fill)settool(tool_pencil);
 	dr.brush=brush;
 }
@@ -3172,8 +3172,8 @@ void ltoolbar(pair pos,pair dn){
 	toolbar_scroll=CLAMP(0,toolbar_scroll,bs->c);int th=bs->c?17:tcellh;
 	pair size=buff_size(TOOLB);frame=draw_buffer(TOOLB);
 	memset(frame.buffer->sv,0,frame.buffer->c),draw_box((rect){0,0,size.x,size.y},0,1),draw_rect((rect){0,6*tcellh,size.x,tgap},1);
-	if(toolbtn(pos,dn,(rect){0     ,0,tcellw+1,tcellh+1},0,uimode==mode_interact))setmode(mode_interact),ev.mu=ev.md=0;
-	if(toolbtn(pos,dn,(rect){tcellw,0,tcellw+1,tcellh+1},1,uimode==mode_object  ))setmode(mode_object  ),ev.mu=ev.md=0;
+	if(toolbtn(pos,dn,(rect){0     ,0,tcellw+1,tcellh+1},0,uimode==mode_interact))setuimode(mode_interact),ev.mu=ev.md=0;
+	if(toolbtn(pos,dn,(rect){tcellw,0,tcellw+1,tcellh+1},1,uimode==mode_object  ))setuimode(mode_object  ),ev.mu=ev.md=0;
 	for(int z=0;z<10;z++){if(toolbtn(pos,dn,(rect){(z%2)*tcellw,(1+(z/2))*tcellh,tcellw+1,tcellh+1},z+2,uimode==mode_draw&&dr.tool==z))settool(z),ev.mu=ev.md=0;}
 	int cy=(6*tcellh)+tgap;int brow=0;for(int z=0;z<12-toolbar_scroll;z++){
 		brushbtn(pos,dn,(rect){0     ,cy,tcellw+1,th+1},z   +toolbar_scroll);
@@ -3260,8 +3260,8 @@ void event_key(int c,int m,int down,const char*name){
 			if(c==KEY_RIGHT)msg.target_navigate=ifield(deck,"card"),msg.arg_navigate=lmistr("right");
 		}
 		if((uimode==mode_interact||uimode==mode_object||uimode==mode_draw)&&ms.type==modal_none&&!kc.on&&deck&&!lb(ifield(deck,"locked"))){
-			if(c==KEY_F1)setmode(mode_interact);
-			if(c==KEY_F2)setmode(mode_object);
+			if(c==KEY_F1)setuimode(mode_interact);
+			if(c==KEY_F2)setuimode(mode_object);
 			int f[]={KEY_F3,KEY_F4,KEY_F5,KEY_F6,KEY_F7,KEY_F8,KEY_F9,KEY_F10,KEY_F11,KEY_F12};
 			for(int z=0;z<10;z++)if(c==f[z])settool(z);
 		}
@@ -3310,7 +3310,7 @@ void event_file(char*p){
 		sound_edit(n_readwav(NULL,l_list(lmutf8(p))));au.sel=(pair){0,0},au.head=0;
 	}
 	if(has_suffix(p,".csv")||has_suffix(p,".psv")){
-		setmode(mode_object);lv*a=lmd();
+		setuimode(mode_object);lv*a=lmd();
 		lv* dat=n_read(NULL,l_list(lmcstr(p)));
 		lv* sep=lmistr(has_suffix(p,".csv")?",": "|");
 		lv* arg=lml(3);arg->lv[0]=dat,arg->lv[1]=NONE,arg->lv[2]=sep;
@@ -3376,7 +3376,7 @@ void sync(void){
 		finish_flip();
 	}
 	window_set_cursor(uicursor);
-	if(do_panic)setmode(mode_object);
+	if(do_panic)setuimode(mode_object);
 	do_panic=0;
 }
 
@@ -3447,7 +3447,7 @@ int interpret(void){
 }
 void paste_any(void){
 	if(has_clip("%%IMG")){if(menu_item("Paste Image",1,'v')){
-		lv*b=image_read(get_clip())->b;setmode(mode_draw);bg_paste(b,0);
+		lv*b=image_read(get_clip())->b;setuimode(mode_draw);bg_paste(b,0);
 	}}
 	else if(has_clip("%%WGT")){if(menu_item("Paste Widgets",1,'v')){
 		lv*t=get_clip();int f=1,i=6,n=t->c-i;lv*v=pjson(t->sv,&i,&f,&n);
@@ -3515,7 +3515,7 @@ void all_menus(void){
 		menu_bar("Script",1);
 		if(menu_item("Stop",1,'\0')){
 			msg.pending_halt=1;
-			if(ms.type!=modal_query&&ms.type!=modal_listen){if(ms.type!=modal_none){modal_exit(0);}setmode(mode_object);}
+			if(ms.type!=modal_query&&ms.type!=modal_listen){if(ms.type!=modal_none){modal_exit(0);}setuimode(mode_object);}
 		}
 		menu_bar("Edit",(ms.type==modal_input||ms.type==modal_save)&&wid.fv);
 		text_edit_menu();
@@ -3759,8 +3759,8 @@ void all_menus(void){
 	}
 	if(uimode==mode_interact||uimode==mode_draw||uimode==mode_object){
 		menu_bar("Tool",ms.type==modal_none&&!kc.on);
-		if(menu_check("Interact",1,uimode==mode_interact,0))setmode(mode_interact);
-		if(menu_check("Widgets" ,1,uimode==mode_object  ,0))setmode(mode_object);
+		if(menu_check("Interact",1,uimode==mode_interact,0))setuimode(mode_interact);
+		if(menu_check("Widgets" ,1,uimode==mode_object  ,0))setuimode(mode_object);
 		menu_separator();
 		if(menu_check("Select"     ,1,uimode==mode_draw&&dr.tool==tool_select     ,0))settool(tool_select     );
 		if(menu_check("Lasso"      ,1,uimode==mode_draw&&dr.tool==tool_lasso      ,0))settool(tool_lasso      );
@@ -3788,7 +3788,7 @@ void all_menus(void){
 		if(menu_check("Show Animation"   ,1,dr.show_anim   ,0))dr.show_anim   ^=1;
 		if(menu_check("Transparency Mask",1,dr.trans_mask  ,0))dr.trans_mask  ^=1;
 		if(menu_check("Fat Bits"         ,1,dr.fatbits     ,0)){
-			if(ms.type==modal_none&&uimode!=mode_draw)setmode(mode_draw);
+			if(ms.type==modal_none&&uimode!=mode_draw)setuimode(mode_draw);
 			dr.fatbits^=1;if(dr.fatbits){center_fatbits(box_midpoint(bg_has_sel()||bg_has_lasso()?dr.sel_here:con_dim()));}
 		}
 	}
@@ -4069,7 +4069,7 @@ void load_deck(lv*d){
 	resize_window(deck);
 	time_t now;time(&now);seed=0xFFFFFFFF&now;
 	validate_modules();
-	setmode(mode_interact);n_play(NULL,lml2(NONE,lmistr("loop")));msg.next_view=1;
+	setuimode(mode_interact);n_play(NULL,lml2(NONE,lmistr("loop")));msg.next_view=1;
 }
 int main(int argc,char**argv){
 	char*file=NULL;for(int z=1;z<argc;z++){

--- a/c/io_sdl1.h
+++ b/c/io_sdl1.h
@@ -1,0 +1,278 @@
+
+#include <SDL.h>
+
+SDL_Cursor*CURSORS[4];
+
+// keyboard keys
+
+#define KEY_UP           SDLK_UP
+#define KEY_DOWN         SDLK_DOWN
+#define KEY_LEFT         SDLK_LEFT
+#define KEY_RIGHT        SDLK_RIGHT
+#define KEY_PAGEUP       SDLK_PAGEUP
+#define KEY_PAGEDOWN     SDLK_PAGEDOWN
+#define KEY_HOME         SDLK_HOME
+#define KEY_END          SDLK_END
+#define KEY_SPACE        SDLK_SPACE
+#define KEY_BACKSPACE    SDLK_BACKSPACE
+#define KEY_DELETE       SDLK_DELETE
+#define KEY_ESCAPE       SDLK_ESCAPE
+#define KEY_RETURN       SDLK_RETURN
+#define KEY_TAB          SDLK_TAB
+#define KEY_CAPSLOCK     SDLK_CAPSLOCK
+#define KEY_LSHIFT       SDLK_LSHIFT
+#define KEY_RSHIFT       SDLK_RSHIFT
+#define KEY_LCTRL        SDLK_LCTRL
+#define KEY_RCTRL        SDLK_RCTRL
+#define KEY_LGUI         SDLK_LMETA
+#define KEY_RGUI         SDLK_RMETA
+#define KEY_LEFTBRACKET  SDLK_LEFTBRACKET
+#define KEY_RIGHTBRACKET SDLK_RIGHTBRACKET
+#define KEY_0            SDLK_0
+#define KEY_1            SDLK_1
+#define KEY_2            SDLK_2
+#define KEY_3            SDLK_3
+#define KEY_9            SDLK_9
+#define KEY_l            SDLK_l
+#define KEY_j            SDLK_j
+#define KEY_k            SDLK_k
+#define KEY_m            SDLK_m
+#define KEY_t            SDLK_t
+#define KEY_u            SDLK_u
+#define KEY_y            SDLK_y
+#define KEY_F1           SDLK_F1
+#define KEY_F2           SDLK_F2
+#define KEY_F3           SDLK_F3
+#define KEY_F4           SDLK_F4
+#define KEY_F5           SDLK_F5
+#define KEY_F6           SDLK_F6
+#define KEY_F7           SDLK_F7
+#define KEY_F8           SDLK_F8
+#define KEY_F9           SDLK_F9
+#define KEY_F10          SDLK_F10
+#define KEY_F11          SDLK_F11
+#define KEY_F12          SDLK_F12
+
+#define KEYM_LSHIFT      KMOD_LSHIFT
+#define KEYM_RSHIFT      KMOD_RSHIFT
+#define KEYM_LCTRL       KMOD_LCTRL
+#define KEYM_RCTRL       KMOD_RCTRL
+#define KEYM_LALT        KMOD_LALT
+#define KEYM_RALT        KMOD_RALT
+#define KEYM_LGUI        KMOD_LMETA
+#define KEYM_RGUI        KMOD_RMETA
+
+// global interpreter lock
+
+SDL_mutex*gil=NULL;
+void interpreter_lock(void){SDL_LockMutex(gil);}
+void interpreter_unlock(void){SDL_UnlockMutex(gil);}
+
+// resources
+
+void base_path(char*path){snprintf(path,PATH_MAX,"");} // stubbed
+void open_url(char*x){(void)x;} // stubbed
+
+// clipboard
+
+lv* get_clip(void){return lmcstr("");} // stubbed
+void set_clip(lv*x){(void)x;} // stubbed
+
+// audio
+
+#define SFX_FORMAT AUDIO_S8
+#define SFX_CHANNELS 1
+int nosound=0;
+SDL_AudioSpec audio;
+
+void sfx_pump(void*user,Uint8*stream,int len);
+void record_pump(void* userdata,Uint8* stream,int len);
+
+lv*n_readwav(lv*self,lv*a){
+	(void)self;char*name=ls(l_first(a))->sv;
+	Uint8* raw; Uint32 length; SDL_AudioSpec spec; SDL_AudioCVT cvt;
+	if(SDL_LoadWAV(name,&spec,&raw,&length)==NULL)return sound_make(lms(0));
+	if(SDL_BuildAudioCVT(&cvt, spec.format,spec.channels,spec.freq, SFX_FORMAT,SFX_CHANNELS,SFX_RATE)){
+		cvt.len=length,cvt.buf=malloc(cvt.len * cvt.len_mult);
+		memcpy(cvt.buf,raw,length),SDL_FreeWAV(raw),SDL_ConvertAudio(&cvt);
+		raw=cvt.buf, length=cvt.len_cvt;
+	}lv*r=lmv(1);r->c=MIN(length,10*SFX_RATE);r->sv=(char*)raw;return sound_make(r);
+}
+
+int record_possible(void){return 0;} // stubbed
+int record_begin(void){return -1;} // stubbed
+void record_pause(int device){(void)device;} // stubbed
+void record_finish(int device){(void)device;} // stubbed
+
+// input events
+
+void event_quit(void);
+void event_touch(void);
+void event_key(int c,int m,int down,const char*name);
+void event_scroll(pair s);
+void event_pointer_move(pair raw,pair scaled);
+void event_pointer_button(int primary,int down);
+void event_file(char*p);
+void field_input(char*text);
+
+void process_events(pair disp,pair size,int scale){
+	SDL_Event e;
+	while(SDL_WaitEvent(&e)){
+		if(e.type==SDL_QUIT     )event_quit();
+		if(e.type==SDL_USEREVENT)break;
+		if(e.type==SDL_KEYDOWN  ){
+			int c=e.key.keysym.unicode;
+			if(c>=32&&c<127)field_input((char[2]){(char)c,'\0'});
+			event_key(e.key.keysym.sym,e.key.keysym.mod,1,SDL_GetKeyName(e.key.keysym.sym));
+		}
+		if(e.type==SDL_KEYUP    )event_key(e.key.keysym.sym,e.key.keysym.mod,0,SDL_GetKeyName(e.key.keysym.sym));
+		if(e.type==SDL_MOUSEMOTION){
+			pair b={(disp.x-(size.x*scale))/2,(disp.y-(size.y*scale))/2};
+			event_pointer_move((pair){e.motion.x,e.motion.y},(pair){(e.motion.x-b.x)/scale,(e.motion.y-b.y)/scale});
+		}
+		if(e.type==SDL_MOUSEBUTTONDOWN){
+			if(e.button.button==SDL_BUTTON_WHEELUP       )event_scroll((pair){0,1});
+			else if(e.button.button==SDL_BUTTON_WHEELDOWN)event_scroll((pair){0,-1});
+			else                                          event_pointer_button(e.button.button==SDL_BUTTON_LEFT,1);
+		}
+		if(e.type==SDL_MOUSEBUTTONUP){
+			if(e.button.button==SDL_BUTTON_WHEELUP       );
+			else if(e.button.button==SDL_BUTTON_WHEELDOWN);
+			else                                          event_pointer_button(e.button.button==SDL_BUTTON_LEFT,0);
+		}
+		//if(e.type==SDL_FINGERDOWN     )event_touch();
+		//if(e.type==SDL_DROPFILE       )event_file(e.drop.file),SDL_free(e.drop.file);
+	}
+	//SDL_FlushEvent(SDL_USEREVENT);
+}
+
+Uint32 tick_pump(Uint32 interval,void*param){
+	SDL_Event e; SDL_UserEvent u;
+	u.type=e.type=SDL_USEREVENT;
+	u.data1=param;
+	e.user=u;
+	SDL_PushEvent(&e);
+	return interval;
+}
+
+// rendering
+
+// SDL1.2 doesn't have software scaling so we'll do it by hand
+void surface_blit(SDL_Surface*src,SDL_Surface*dst,pair pos,int scale){
+	if(scale==1){
+		SDL_Rect dstrect={pos.x,pos.y,src->w,src->h};
+		SDL_BlitSurface(src,NULL,dst,&dstrect);
+		return;
+	}
+	SDL_LockSurface(src);SDL_LockSurface(dst);
+	int*a=(int*)src->pixels;int*b=(int*)dst->pixels;
+	for(int y=0;y<src->h*scale;y++)for(int x=0;x<src->w*scale;x++)b[(y+pos.y)*dst->w+(x+pos.x)]=a[(y/scale)*src->w+(x/scale)];
+	SDL_UnlockSurface(dst);SDL_UnlockSurface(src);
+}
+
+SDL_Surface*vid;
+SDL_Surface*gfx;
+SDL_Surface*gtool;
+#ifdef LOSPEC
+// a set of customizations intended to make Decker more portable
+// and more performant on extremely limited devices such as the OLPC XO-4.
+int parity=0;
+lv* readimage(char*path,int grayscale){return n_readgif(NULL,lml2(lmcstr(path),grayscale?lmistr("gray"):NONE));}
+int*sgfx=NULL;
+void framebuffer_alloc(pair size,int minscale){
+	SDL_FreeSurface(gfx);
+	gfx=SDL_CreateRGBSurface(0,size.x*minscale,size.y*minscale,32,0,0,0,0);
+	sgfx=calloc(size.x*size.y,sizeof(int));
+}
+int framebuffer_flip(pair disp,pair size,int scale,int mask,int frame,char*pal,lv*buffer){
+	parity^=1;if(!parity)return 0;
+	draw_frame(pal,buffer,sgfx,size.x*4,frame,mask);frame_count++;
+	SDL_LockSurface(gfx);
+	int stride=gfx->pitch/sizeof(int);
+	int*p=gfx->pixels;
+	// SDL's X11 software renderer is outrageously slow at texture upscaling on the OLPC, so we'll do it by hand:
+	if(scale==1)for(int y=0,i=0,o=0;y<size.y;y++,o+=stride)for(int x=0;x<size.x;x++,i++     )p[o+x]=sgfx[i];
+	if(scale==2)for(int y=0,i=0,o=0;y<size.y;y++,o+=stride)for(int x=0;x<size.x;x++,i++,o+=2)p[o]=p[o+1]=p[o+stride]=p[o+stride+1]=sgfx[i];
+	SDL_UnlockSurface(gfx);
+	SDL_Rect dst={(disp.x-scale*size.x)/2,(disp.y-scale*size.y)/2,scale*size.x,scale*size.y};
+	SDL_BlitSurface(gfx,NULL,vid,&dst);
+	return 1;
+}
+#else
+#include <SDL_image.h>
+lv* readimage(char*path,int grayscale){
+	SDL_Surface*b=IMG_Load(path);if(b==NULL)return image_empty();lv*i=lmbuff((pair){b->w,b->h});
+	SDL_Surface*c=SDL_DisplayFormat(b);
+	for(int y=0;y<b->h;y++)for(int x=0;x<b->w;x++){
+		Uint32 v=((Uint32*)c->pixels)[x+(y*c->pitch/4)];Uint8 cr,cg,cb,ca;
+		SDL_GetRGBA(v,c->format,&cr,&cg,&cb,&ca),i->sv[x+y*b->w]=(ca!=0xFF)?(grayscale?0xFF:0x00):readcolor(cr,cg,cb,grayscale);
+	}SDL_FreeSurface(c),SDL_FreeSurface(b);return image_make(i);
+}
+void framebuffer_alloc(pair size,int minscale){
+	(void)minscale;
+	SDL_FreeSurface(gfx);
+	gfx=SDL_CreateRGBSurface(0,size.x,size.y,32,0,0,0,0);
+}
+int framebuffer_flip(pair disp,pair size,int scale,int mask,int frame,char*pal,lv*buffer){
+	SDL_LockSurface(gfx);
+	draw_frame(pal,buffer,gfx->pixels,gfx->pitch,frame,mask);frame_count++;
+	SDL_UnlockSurface(gfx);
+	pair pos={(disp.x-scale*size.x)/2,(disp.y-scale*size.y)/2};
+	surface_blit(gfx,vid,pos,scale);
+	return 1;
+}
+#endif
+
+void toolbar_flip(lv*buffer,int frame,char*pal,rect dest){
+	pair tsize=buff_size(buffer);
+	SDL_Rect src={0,0,tsize.x,tsize.y},dst={dest.x,dest.y,dest.w,dest.h};
+	if(!gtool){pair s=buff_size(buffer);gtool=SDL_CreateRGBSurface(0,s.x,s.y,32,0,0,0,0);}
+	SDL_LockSurface(gtool);
+	draw_frame(pal,buffer,gtool->pixels,gtool->pitch,frame,0);
+	SDL_UnlockSurface(gtool);
+	SDL_BlitSurface(gtool,&src,vid,&dst);
+}
+void finish_flip(void){SDL_Flip(vid);}
+
+// windows
+
+pair get_display_size(void){return (pair){800,600};} // stubbed
+int get_display_density(pair disp){(void)disp;return 1;} // stubbed
+void window_set_title(char*x){SDL_WM_SetCaption(x,NULL);}
+void window_set_opacity(float x){(void)x;} // stubbed
+void window_set_cursor(int x){SDL_SetCursor(CURSORS[x]);}
+void window_set_fullscreen(int full){vid=SDL_SetVideoMode(vid->w,vid->h,32,SDL_DOUBLEBUF | (full?SDL_FULLSCREEN:0));}
+pair window_get_size(void){return (pair){vid->w,vid->h};}
+void window_set_size(pair wsize,pair size,int scale){
+	vid=SDL_SetVideoMode(size.x*scale,size.y*scale,32,SDL_DOUBLEBUF);
+	window_set_title("Decker");
+	framebuffer_alloc(size,scale);
+}
+
+// entrypoint
+
+void tick(lv*env);
+void sync(void);
+
+void io_init(void){
+	SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER | (nosound?0:SDL_INIT_AUDIO));
+	gil=SDL_CreateMutex();
+	//CURSORS[0]=SDL_GetDefaultCursor();
+	//CURSORS[1]=SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_HAND);
+	//CURSORS[2]=SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_IBEAM);
+	//CURSORS[3]=SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_SIZEALL);
+	if(!nosound){
+		audio.freq=SFX_RATE;
+		audio.format=SFX_FORMAT;
+		audio.channels=SFX_CHANNELS;
+		audio.samples=(SFX_RATE/10);
+		audio.callback=sfx_pump;
+		SDL_OpenAudio(&audio,NULL),SDL_PauseAudio(0);
+	}
+	SDL_AddTimer((1000/60),tick_pump,NULL);
+	SDL_EnableUNICODE(1);
+	SDL_EnableKeyRepeat(SDL_DEFAULT_REPEAT_DELAY,SDL_DEFAULT_REPEAT_INTERVAL);
+}
+void io_run(lv*env){
+	while(!should_exit){tick(env);sync();}
+}

--- a/c/io_sdl2.h
+++ b/c/io_sdl2.h
@@ -175,7 +175,6 @@ void framebuffer_alloc(pair size,int minscale){
 }
 int framebuffer_flip(pair disp,pair size,int scale,int mask,int frame,char*pal,lv*buffer){
 	parity^=1;if(!parity)return 0;
-	int mask=dr.trans_mask&&uimode==mode_draw;
 	draw_frame(pal,buffer,sgfx,size.x*4,frame,mask);frame_count++;
 	int*p, pitch;
 	SDL_LockTexture(gfx,NULL,(void**)&p,&pitch);
@@ -265,7 +264,7 @@ void tick(lv*env);
 void sync(void);
 
 void io_init(void){
-	SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER | SDL_INIT_JOYSTICK | (nosound?0:SDL_INIT_AUDIO));
+	SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER | (nosound?0:SDL_INIT_AUDIO));
 	gil=SDL_CreateMutex();
 	CURSORS[0]=SDL_GetDefaultCursor();
 	CURSORS[1]=SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_HAND);

--- a/c/io_sdl2.h
+++ b/c/io_sdl2.h
@@ -53,6 +53,15 @@ SDL_Cursor*CURSORS[4];
 #define KEY_F11          SDLK_F11
 #define KEY_F12          SDLK_F12
 
+#define KEYM_LSHIFT      KMOD_LSHIFT
+#define KEYM_RSHIFT      KMOD_RSHIFT
+#define KEYM_LCTRL       KMOD_LCTRL
+#define KEYM_RCTRL       KMOD_RCTRL
+#define KEYM_LALT        KMOD_LALT
+#define KEYM_RALT        KMOD_RALT
+#define KEYM_LGUI        KMOD_LGUI
+#define KEYM_RGUI        KMOD_RGUI
+
 // global interpreter lock
 
 SDL_mutex*gil=NULL;


### PR DESCRIPTION
First draft of a SDL1.2 implementation for old platforms, with SDL2-exclusive features stubbed out, and rendering replaced with a basic software scaler.
Replace `sdl2-config` with `sdl-config` in the makefile to try it out.