### PR TITLE
Accept leading underscores and question marks in codemirror syntax

### DIFF
--- a/syntax/codemirror/lilmode.js
+++ b/syntax/codemirror/lilmode.js
@@ -30,7 +30,7 @@ CodeMirror.defineMode('lil',(config,options)=>{
 			if(stream.match('"')){state.mode='str';return'string'}
 			// line comments, keywords/builtins, function definitions:
 			if(stream.match('#')||stream.match(/[\t\n\r ]+\//))return stream.skipToEnd(),'comment'
-			const n=stream.match(/^[a-zA-Z][a-zA-Z0-9_?]*/)
+			const n=stream.match(/^[a-zA-Z_?][a-zA-Z0-9_?]*/)
 			if(state.mode=='fname'&&n){state.mode=0;return 'property'}
 			if(n=='on'){state.mode='fname'}
 			if(KEYWORDS[n])return 'keyword'


### PR DESCRIPTION
Lil syntax allows names starting with `_` and `?` which is not reflected by the codemirror syntax.

I guess you use this syntax in the Lil playground where I stumbled upon this:
![Code in the Lil playground highlighting the missing highlight](https://github.com/user-attachments/assets/9ba03d4e-5817-46c2-a04e-22f31b245033)

I looked through the other syntax definitions and they handle generic names correctly (except for the emacs one which doesn't do any generic name highlighting).