### PR TITLE
Add MIME type to Decker.desktop

### DIFF
--- a/Decker.desktop
+++ b/Decker.desktop
@@ -6,3 +6,4 @@ Icon=decker
 Terminal=false
 Type=Application
 Categories=Graphics;2DGraphics;RasterGraphics;
+MimeType=application/x-decker;


### PR DESCRIPTION
This associates the application with the file type, so that if you double-click on a .deck file in a file manager, Decker will be used to open it. Without the MIME type in there, my file manager (Nemo) won't even suggest Decker at all.