### PR TITLE
Increase ev.clicktime for touchpad usability

### DIFF
--- a/c/decker.c
+++ b/c/decker.c
@@ -3349,7 +3349,7 @@ void event_pointer_move(pair raw,pair scaled){
 void event_pointer_button(int primary,int down){
 	if(down){
 		ev.rawdpos=ev.rawpos;
-		pointer_held=ev.drag=1;pointer_start=ev.dpos=pointer;ev.md=1;ev.clicktime=10;
+		pointer_held=ev.drag=1;pointer_start=ev.dpos=pointer;ev.md=1;ev.clicktime=12;
 		ev.down_modal=ms.type,ev.down_uimode=uimode,ev.down_caps=kc.on;
 		if(!primary)ev.rdown=1;
 	}

--- a/js/decker.js
+++ b/js/decker.js
@@ -3591,7 +3591,7 @@ sync=_=>{
 move=(x,y)=>{if(!msg.pending_drag)pointer.prev=pointer.pos;pointer.pos=ev.pos=rect(x,y);if(pointer.held)msg.pending_drag=1}
 down=(x,y,alt)=>{
 	ev.rawdpos=ev.rawpos,ev.down_modal=ms.type,ev.down_uimode=uimode,ev.down_caps=kc.on
-	move(x,y),pointer.held=ev.drag=1;pointer.start=ev.dpos=pointer.pos,ev.md=1,ev.clicktime=10;if(alt)ev.rdown=1;initaudio()}
+	move(x,y),pointer.held=ev.drag=1;pointer.start=ev.dpos=pointer.pos,ev.md=1,ev.clicktime=12;if(alt)ev.rdown=1;initaudio()}
 up=(x,y,alt)=>{
 	move(x,y),pointer.held=ev.drag=0,pointer.end=pointer.pos,ev.mu=1;if(alt)ev.rup=1
 	if(ev.clicktime)ev.click=1;ev.clicktime=0;if(ev.clicklast)ev.dclick=1;ev.clicklast=DOUBLE_CLICK_DELAY


### PR DESCRIPTION
When using tap-to-click on a laptop touchpad, there is a delay between the mousedown and mouseup events. At least on my laptop, this delay is significant: no matter how quickly I tap, the mouse events are spaced apart by about 170-180 ms. This is longer than what ev.clicktime allows, meaning tap-to-click doesn't register as a click to Decker; this makes things like menus slightly frustrating to operate on a touchpad because of the difference in behavior compared to clicking a regular mouse.

This commit increases ev.clicktime from 10 to 12 frames; at 60 fps, this bumps up the click-recognition delay to an even 200 ms.