### PR TITLE
Add NetBSD build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,13 @@ ifeq ($(UNAME),OpenBSD)
 	FLAGS:=$(FLAGS) -Wno-misleading-indentation -Wno-unknown-warning-option
 	FLAGS:=$(FLAGS) -lm
 endif
+ifeq ($(UNAME),NetBSD)
+	# Required packages: bash, gmake, SDL2, SDL2_image, xdg-tools
+	OPEN=xdg-open
+	COMPILER=gcc
+	FLAGS=-std=c99 -lm -Wall -Wextra -O2
+	FLAGS:=$(FLAGS) -Wno-misleading-indentation -Wno-format-truncation
+endif
 ifneq ("$(EXTRA_FLAGS)","")
 	FLAGS:=$(FLAGS) $(EXTRA_FLAGS)
 endif

--- a/c/dom.h
+++ b/c/dom.h
@@ -3043,6 +3043,9 @@ lv*n_dir(lv*self,lv*a){
 	r->kv[0]=lmistr("dir");return r;
 }
 #ifndef _WIN32
+#ifdef __NetBSD__
+#include <sys/wait.h>
+#endif
 lv*n_shell(lv*self,lv*a){
 	(void)self;lv*x=ls(l_first(a)),*r=lmd();FILE*child=popen(x->sv,"r");str o=str_new();
 	while(1){int c=fgetc(child);if(feof(child))break;str_addraw(&o,c);}int e=pclose(child);lv*os=lmstr(o);


### PR DESCRIPTION
Disclaimer: this is the first thing I've ever built on NetBSD. (I am attempting Deck-Month 2 on a 25 year old laptop, which limits my choice of OS, since I only have 128 MB of RAM.)

Having said that, there are two changes that allowed me to get this building (and running) on NetBSD 10.1 (i386):

1. **Add NetBSD branch to the Makefile** -- very similar to OpenBSD, just with GCC (note: I saw many "char-subscripts" warnings that I believe are unrelated to NetBSD, although I haven't confirmed that yet)
2. **Explicitly include `sys/wait.h`** -- without this, `WIFEXITED` and `WEXITSTATUS` aren't defined, resulting in a failed build

Note: I don't immediately know why `sys/wait.h` was (apparently) not required on Linux/OpenBSD/macOS. **Would it be better to *only* include this header on NetBSD?** That would be a more scoped change, but my current understanding is that `WIFEXITED` is defined in `sys/wait.h`, so it seems reasonable to always include it.

Related to previous: I have no way to test on macOS.