### PR TITLE
allow lilt to run any input file

### DIFF
--- a/c/lilt.c
+++ b/c/lilt.c
@@ -117,17 +117,18 @@ int main(int argc,char**argv){
 			if(has_suffix(path,".lil"))runfile(path,env);
 		}}closedir(dir);
 	}
-	int repl=1;for(int z=1;z<argc;z++){
-		if(!strcmp(argv[z],"-h")){repl=0;
+	for(int z=1;z<argc;z++){
+		if(!strcmp(argv[z],"-h")){
 			printf("usage: %s [FILE.lil...] [-e EXPR...]\nif present, execute a FILE and exit\n",argv[0]);
 			printf("-e : evaluate STRING and exit\n-h : display this information\n");
 		}
-		else if(!strcmp(argv[z],"-e")){repl=0;
+		else if(!strcmp(argv[z],"-e")){
 			if(z+1>=argc)fprintf(stderr,"no expression specified.\n"),exit(1);
 			runstring(argv[z+1],env),z++;
 		}
-		else if(has_suffix(argv[z],".lil")){repl=0;runfile(argv[z],env),z++;}
-	}if(!repl){exit(0);}
+		else{runfile(argv[z],env);}
+		if(z==argc-1)exit(0);
+	}
 	while(1){
 		char*line=bestlineWithHistory(" ","lilt");
 		if (!line)break;


### PR DESCRIPTION
Lilt currently will not execute a file unless it has a ".lil" extension:
```
$ ./lilt foo
 exit[]
$ mv foo foo.lil
$ ./lilt foo.lil 
+---------------+-----+
| job           | avg |
+---------------+-----+
| "Development" | 33  |
| "Sales"       | 28  |
| "Accounting"  | 43  |
+---------------+-----+
```
Instead of running `foo`, I get dropped into the repl. I'd like lilt to try and run any input file. Why? I use a vim plugin that works like this:

```
#!/usr/bin/env lilt
data: insert name age job with
 "Alice"  25 "Development" 
 "Sam"    28 "Sales"
 "Thomas" 40 "Development"
 "Sara"   34 "Development"
 "Walter" 43 "Accounting"
end
on avg x do sum x/count x end
show[select job:first job avg[age] by job from data]
#$
+---------------+-----+
| job           | avg |
+---------------+-----+
| "Development" | 33  |
| "Sales"       | 28  |
| "Accounting"  | 43  |
+---------------+-----+
#~

#!/usr/bin/env python
#!!</tmp/data
while line:=input():
    x = int(line)
    print(2**x)
#$
1024
8388608
4294967296
8796093022208
#~
```
You can define different scripts in a buffer, run them, and the output gets dumped into the same buffer. This works by just writing everything between `#!` and `#$` to a temp file like `/tmp/CTNIh` and running it. Lilt is the only scripting language I've encountered where this doesn't work.

# Tests
I believe all the ways of using lilt are still working:
```
$ ./lilt -h
usage: ./lilt [FILE.lil...] [-e EXPR...]
if present, execute a FILE and exit
-e : evaluate STRING and exit
-h : display this information
$ ./lilt -e "show[1]" -e "show[2]"
1
2
$ ./lilt foo 
+---------------+-----+
| job           | avg |
+---------------+-----+
| "Development" | 33  |
| "Sales"       | 28  |
| "Accounting"  | 43  |
+---------------+-----+
$ ./lilt 
 show["in repl"]
"in repl"
"in repl"
```
