### PR TITLE
fix: modal fill-pattern picker writes to dr.pattern instead of dr.fill

### DIFF
--- a/c/decker.c
+++ b/c/decker.c
@@ -1995,7 +1995,7 @@ void modals(void){
 	}
 	else if(ms.type==modal_pattern||ms.type==modal_fill||ms.type==modal_widpattern||ms.type==modal_spanpattern){
 		pair grid={8,6};int ss=25, gs=ss+4, m=5, lh=font_h(FONT_BODY);
-		int*v=ms.type==modal_widpattern||ms.type==modal_spanpattern?&ob.pending_pattern: modal_pattern?&dr.pattern: &dr.fill;
+		int*v=ms.type==modal_widpattern||ms.type==modal_spanpattern?&ob.pending_pattern: ms.type==modal_pattern?&dr.pattern: &dr.fill;
 		rect b=draw_modalbox((pair){m+(grid.x*gs)+m,m+(grid.y*gs)+lh+m});
 		char*label=ms.type==modal_widpattern||ms.type==modal_spanpattern?"Choose a pattern.":
 		    ms.type==modal_fill?"Choose a fill pattern.":"Choose a stroke pattern.";


### PR DESCRIPTION
## Summary

The third branch of the ternary at `c/decker.c:1998` used the bare enum constant `modal_pattern` instead of `ms.type==modal_pattern`. Because `modal_pattern` is a non-zero enum value, the condition is always true, so `v` always points to `&dr.pattern` and never to `&dr.fill`.

```diff
- int*v=ms.type==modal_widpattern||ms.type==modal_spanpattern?&ob.pending_pattern: modal_pattern?&dr.pattern: &dr.fill;
+ int*v=ms.type==modal_widpattern||ms.type==modal_spanpattern?&ob.pending_pattern: ms.type==modal_pattern?&dr.pattern: &dr.fill;
```

Effect: opening the **Style → Fill…** modal (or pressing `2` in draw mode) to pick a fill pattern silently writes the chosen index into `dr.pattern` (the stroke pattern). `dr.fill` remains `0` (background). The Filled Box / Filled Ellipse tools then draw the user's intended fill pattern as the *outline* and leave the interior blank.

The JS implementation does the right thing at `js/decker.js:2023` (`ms.type=='pattern'?dr.pattern=x:dr.fill=x`), so this is C-only and matches the recurring C/JS divergence theme.

## Reproduce (before fix)

1. Fresh deck.
2. **Style → Fill…**, pick a clearly cross-hatched pattern (e.g. the brick pattern).
3. Select the Filled Box tool.
4. Drag a box on the canvas.

Observed: outline drawn with the picked pattern, interior empty.

![before fix](https://raw.githubusercontent.com/duckfriend123/Decker/assets/fillfix-screenshots/screenshots/before-fix.png)

## After fix

Same steps, with this one-character change applied:

![after fix](https://raw.githubusercontent.com/duckfriend123/Decker/assets/fillfix-screenshots/screenshots/after-fix.png)

## Test plan

- [x] Confirmed identical behavior in web build (already correct).
- [x] Rebuilt native Decker with the fix, verified both filled-box (brick fill in the screenshot) and filled-ellipse render the picked fill pattern in their interiors.
- [x] Stroke pattern (Style → Stroke… and `1` key) and the right-toolbar palette continue to behave correctly (unchanged code paths).
- [ ] The right-toolbar Fill picker (`palbtn` at `c/decker.c:3368`) was already correct and unaffected.

The Decker version targeted by this change is 1.66 (HEAD = commit `edc2300`).